### PR TITLE
Create helpers.rb

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -145,7 +145,7 @@ module AbstractController
       #
       def helper(*args, &block)
         modules_for_helpers(args).each do |mod|
-          next if _helpers.include?(mod)
+          next if mod.class == Class || _helpers.include?(mod)
           _helpers_for_modification.include(mod)
         end
 


### PR DESCRIPTION
Rails' code fails when we inherit `ActionController::Base`; the above fixes it